### PR TITLE
fix: unmock browser environment after it is not needed

### DIFF
--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -100,10 +100,11 @@ export async function build(ssgOptions: Partial<ViteReactSSGOptions> = {}, viteC
     mode: config.mode,
   }))
 
+  let unmock = () => {}
   if (mock) {
     // @ts-expect-error allow js
-    const { jsdomGlobal }: { jsdomGlobal: () => void } = await import('./jsdomGlobal.mjs')
-    jsdomGlobal()
+    const { jsdomGlobal }: { jsdomGlobal: () => () => void } = await import('./jsdomGlobal.mjs')
+    unmock = jsdomGlobal()
   }
 
   // server
@@ -253,6 +254,7 @@ export async function build(ssgOptions: Partial<ViteReactSSGOptions> = {}, viteC
 
   await fs.remove(join(root, '.vite-react-ssg-temp'))
 
+  unmock()
   const pwaPlugin: { disabled: boolean, generateSW: () => Promise<unknown> } = config.plugins.find(i => i.name === 'vite-plugin-pwa')?.api
   if (pwaPlugin && !pwaPlugin.disabled && pwaPlugin.generateSW) {
     buildLog('Regenerate PWA...')


### PR DESCRIPTION
Hello, I have trouble when using vite-react-ssg with vite-plugin-pwa. I am getting an error 'The URL must be of scheme file' during build. Here is a link to the repo with reproduction of the problem: [link](https://github.com/GravityTwoG/vite-react-ssg-pwa-repro). Just install dependencies and run `npm run build`
![Screenshot 2025-01-19 at 18 28 29](https://github.com/user-attachments/assets/33e75873-d439-4d67-b501-8345d8ea03e2)

As I investigated, the error is thrown from @rollup-plugin/terser which changes its behavior depending on the environment:
link: https://www.npmjs.com/package/@rollup/plugin-terser?activeTab=code, line 160
```javascript
if (!workerPool) {
    workerPool = new WorkerPool({
        filePath: url.fileURLToPath((typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.src || new URL('index.js', document.baseURI).href))),
        maxWorkers
    });
}
```

In [src/node/build](https://github.com/Daydreamer-riri/vite-react-ssg/blob/b0cb9a4aaeea180a3dd19023ad2333397eed2694/src/node/build.ts#L106) jsdomGlobal returns cleanup function that deletes all mocked objects from global environment. So I've added a call of the cleanup function before running the pwa plugin. I am not sure if it is the right place for it, but it seems to be working for me.