### PR TITLE
feat(config): add htmlEntry option for custom index.html path (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,11 @@ interface ViteReactSSGOptions {
    */
   entry?: string
   /**
+   * The path of the index.html file (relative to the project root).
+   * @default 'index.html'
+   */
+  htmlEntry?: string
+  /**
    * Mock browser global variables (window, document, etc...) from SSG.
    *
    * @default false

--- a/docs/src/pages/docs/Configuration.md
+++ b/docs/src/pages/docs/Configuration.md
@@ -116,6 +116,18 @@ string
 
 The path of the main entry file (relative to the project root).
 
+### htmlEntry
+
+#### type
+
+```ts
+string
+```
+
+**default** `'index.html'`
+
+The path of the index.html file (relative to the project root).
+
 ### mock
 
 #### type
@@ -193,7 +205,7 @@ CrittersOptions | false
 
 Options for the critters packages.
 
-@see https://github.com/GoogleChromeLabs/critters
+@see <https://github.com/GoogleChromeLabs/critters>
 
 ### onBeforePageRender
 

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -53,7 +53,8 @@ export async function build(ssgOptions: Partial<ViteReactSSGOptions> = {}, viteC
   const {
     script = 'sync',
     mock = false,
-    entry = await detectEntry(root),
+    htmlEntry = 'index.html',
+    entry = await detectEntry(root, htmlEntry),
     formatting = 'none',
     includedRoutes: configIncludedRoutes = DefaultIncludedRoutes,
     onBeforePageRender,
@@ -86,7 +87,7 @@ export async function build(ssgOptions: Partial<ViteReactSSGOptions> = {}, viteC
       ssrManifest: true,
       rollupOptions: {
         input: {
-          app: join(root, './index.html'),
+          app: join(root, htmlEntry || './index.html'),
         },
         // @ts-expect-error rollup type
         onLog(level, log, handler) {
@@ -170,7 +171,8 @@ export async function build(ssgOptions: Partial<ViteReactSSGOptions> = {}, viteC
 
   const ssrManifest: SSRManifest = JSON.parse(await fs.readFile(join(out, ...dotVitedir, 'ssr-manifest.json'), 'utf-8'))
   const manifest: Manifest = JSON.parse(await fs.readFile(join(out, ...dotVitedir, 'manifest.json'), 'utf-8'))
-  let indexHTML = await fs.readFile(join(out, 'index.html'), 'utf-8')
+  let indexHTML = await fs.readFile(join(out, htmlEntry), 'utf-8')
+  fs.rmSync(join(out, htmlEntry))
   indexHTML = rewriteScripts(indexHTML, script)
 
   const queue = new PQueue({ concurrency })

--- a/src/node/dev.ts
+++ b/src/node/dev.ts
@@ -15,7 +15,8 @@ export async function dev(ssgOptions: Partial<ViteReactSSGOptions> = {}, viteCon
   const root = config.root || cwd
 
   const {
-    entry = await detectEntry(root),
+    htmlEntry = 'index.html',
+    entry = await detectEntry(root, htmlEntry),
     onBeforePageRender,
     onPageRendered,
     rootContainerId = 'root',
@@ -23,7 +24,7 @@ export async function dev(ssgOptions: Partial<ViteReactSSGOptions> = {}, viteCon
   }: ViteReactSSGOptions = Object.assign({}, config.ssgOptions || {}, ssgOptions)
 
   const ssrEntry = await resolveAlias(config, entry)
-  const template = await fs.readFile(join(root, 'index.html'), 'utf-8')
+  const template = await fs.readFile(join(root, htmlEntry), 'utf-8')
   let viteServer: ViteDevServer
 
   // @ts-expect-error global var

--- a/src/node/html.ts
+++ b/src/node/html.ts
@@ -75,11 +75,11 @@ export async function renderHTML({
   return renderedOutput
 }
 
-export async function detectEntry(root: string) {
+export async function detectEntry(root: string, htmlEntry: string = 'index.html') {
   // pick the first script tag of type module as the entry
   // eslint-disable-next-line regexp/no-super-linear-backtracking, regexp/no-useless-non-capturing-group, regexp/no-dupe-characters-character-class, regexp/no-useless-lazy, regexp/no-useless-flag, regexp/no-useless-escape, regexp/strict
   const scriptSrcReg = /<script(?:.*?)src=["'](.+?)["'](?!<)(?:.*)\>(?:[\n\r\s]*?)(?:<\/script>)/gim
-  const html = await fs.readFile(join(root, 'index.html'), 'utf-8')
+  const html = await fs.readFile(join(root, htmlEntry), 'utf-8')
   const scripts = [...html.matchAll(scriptSrcReg)]
   const [, entry] = scripts.find(matchResult => {
     const [script] = matchResult

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,10 @@ export interface ViteReactSSGOptions<Context = ViteReactSSGContext> {
    */
   entry?: string
   /**
+   * The path of the index.html file (relative to the project root).
+   */
+  htmlEntry?: string
+  /**
    * Mock browser global variables (window, document, etc...) from SSG.
    *
    * @default false

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export interface ViteReactSSGOptions<Context = ViteReactSSGContext> {
   entry?: string
   /**
    * The path of the index.html file (relative to the project root).
+   * @default 'index.html'
    */
   htmlEntry?: string
   /**


### PR DESCRIPTION
- Add htmlEntry option to ViteReactSSGOptions
- Update build, dev and detectEntry functions to use custom HTML entry
- Default htmlEntry to 'index.html' for backward compatibility
- Clean up client build HTML entry file after build

