### PR TITLE
Fix incorrect theme FOUC on page load

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="/toggle-theme.js"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script src="/toggle-theme.js"></script>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
## Issue
The docs site flashes white every time the page is reloaded, even when the system theme is dark, or the dark theme has been selected and stored in localstorage.

## Solution
This PR moves the theme selection script into the <head> of the document to prevent this flash. Now the system theme or theme selection from local storage will be active before content is shown. Page load speeds have not changed from what I can tell (limited testing of a few pages in devtools).