### PR TITLE
fix(client): use render() for non-SSR shells in production, not just development

### DIFF
--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -140,7 +140,14 @@ export function ViteReactSSG(
       )
       const isSSR
         = document.querySelector('[data-server-rendered=true]') !== null
-      if (!isSSR && process.env.NODE_ENV === 'development') {
+      // Use render() whenever the served HTML isn't a real prerender for
+      // this route. The `data-server-rendered` marker is the source of
+      // truth — checking NODE_ENV in addition was actively harmful in
+      // production: hosts that serve a SPA shell as the fallback for
+      // unmatched URLs would always hit the `else` branch and try to
+      // hydrate an empty `<div id="root">` against a non-empty client
+      // tree, throwing React #418/#422 for every non-prerendered visit.
+      if (!isSSR) {
         render(app, container, options)
       }
       else {

--- a/src/client/single-page.tsx
+++ b/src/client/single-page.tsx
@@ -90,7 +90,10 @@ export function ViteReactSSG(
         </HelmetProvider>
       ) as React.ReactElement
       const isSSR = document.querySelector('[data-server-rendered=true]') !== null
-      if (!isSSR && process.env.NODE_ENV === 'development') {
+      // See `src/client/index.tsx` for the rationale — hydrating an SPA
+      // shell against a non-empty client tree throws React #418 in prod,
+      // and the `data-server-rendered` marker is enough to distinguish.
+      if (!isSSR) {
         render(app, container, options)
       }
       else {

--- a/src/client/tanstack.tsx
+++ b/src/client/tanstack.tsx
@@ -218,7 +218,10 @@ export function Experimental_ViteReactSSG(
       const { router } = context
       const isSSR
         = document.querySelector('[data-server-rendered=true]') !== null
-      if (!isSSR && process.env.NODE_ENV === 'development') {
+      // See `src/client/index.tsx` for the rationale — hydrating an SPA
+      // shell against a non-empty client tree throws React #418 in prod,
+      // and the `data-server-rendered` marker is enough to distinguish.
+      if (!isSSR) {
         render(
           <HelmetProvider>
             <RouterProvider router={router} />


### PR DESCRIPTION
## What

Drops the `NODE_ENV === "development"` gate on the client runtime's `render()` vs `hydrate()` decision across all three router adapters (`index.tsx`, `single-page.tsx`, `tanstack.tsx`). The `data-server-rendered="true"` marker is the source of truth for whether the served HTML is a real prerender for the current route; that signal is correct in both dev and prod, so the hardcoded NODE_ENV check is unnecessary and actively harmful in production.

## Why

When `prerender` covers a subset of routes (e.g. marketing pages but not auth-walled app routes), most static hosts serve `dist/index.html` (or another SPA shell with no `data-server-rendered`) as the fallback for unmatched URLs. The matching client tree for those routes has children, but the shell body is just `<div id="root"></div>`. With the current logic, production builds always hydrate, producing **React errors #418 / #422 (\"Hydration failed because the initial UI does not match what was rendered on the server\")** for every non-prerendered visit:

\`\`\`ts
const isSSR = document.querySelector('[data-server-rendered=true]') !== null
if (!isSSR && process.env.NODE_ENV === 'development') {
  render(app, container, options)
} else {
  // ← prod fall-through: hydrates an empty shell against a non-empty client tree
  hydrate(app, container, options)
}
\`\`\`

In dev the same code takes \`render()\` correctly because Vite leaves \`NODE_ENV === \"development\"\`. After production build inlines \`NODE_ENV === \"production\"\`, the condition collapses and the runtime hydrates everything, including SPA shells.

## How

The diff is one line per call site — drop the NODE_ENV clause. Same fix applied across all three adapters (\`index.tsx\` for the standard router, \`single-page.tsx\`, \`tanstack.tsx\`):

\`\`\`diff
        const isSSR = document.querySelector('[data-server-rendered=true]') !== null
-       if (!isSSR && process.env.NODE_ENV === 'development') {
+       if (!isSSR) {
          render(app, container, options)
        }
        else {
          hydrate(app, container, options)
        }
\`\`\`

## Verification

- I've been shipping this as a \`patch-package\` patch on \`0.9.1-beta.1\` (against the bundled \`dist/index.mjs\`) for ~24 hours on a production React Router v6 + vite-react-ssg site (\`keytopia.org\`). Behavior:
  - Prerendered routes still **hydrate** against their matching baked HTML (no change there — \`isSSR\` is true on those pages).
  - Non-prerendered routes (e.g. \`/dashboard\`, \`/games/race\`, \`/practice\`) now **render fresh** against the SPA shell. No console errors. No React #418.
  - No visible flicker on first paint for either case.
- Locally on this branch:
  - \`pnpm typecheck\` clean.
  - \`pnpm lint\` clean (no new warnings).
  - \`pnpm build\` succeeds. Built \`dist/index.mjs\` confirms the hydrate decision now reads \`if (!isSSR)\` without the NODE_ENV clause.

Happy to add a regression test if you'd like (Playwright against a build with mixed prerendered + SPA-shell-fallback routes, asserting console is clean on the shell route). Wanted to keep this PR minimal first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)